### PR TITLE
Added color scheme to all the messages (R, G, B), ItemHax tweak

### DIFF
--- a/Buildaria/Buildaria/Core.cs
+++ b/Buildaria/Buildaria/Core.cs
@@ -77,6 +77,7 @@ namespace Buildaria
         bool buildMode = true;
         bool itemsEnabled = false;
         bool displayMessages = true;
+        bool lightme = false;
 
         #endregion
 
@@ -526,6 +527,25 @@ namespace Buildaria
                     }
                 }
 
+                #endregion
+                
+                #region Light me
+
+                if (keyState.IsKeyDown(Keys.F) && !oldKeyState.IsKeyDown(Keys.F) && !editSign)
+                {
+                    lightme = !lightme;
+                                        
+                    if (displayMessages)
+                    {
+                        Main.NewText("Light me = " + lightme, 255, 255, 0);
+                    }
+
+                }
+                if (lightme)
+                {
+                    player[myPlayer].AddBuff(11, 1, false);
+                }       
+                
                 #endregion
 
                 bool allowStuff = true; // Disallows most buildaria functionality in-game


### PR DESCRIPTION
White - Display messages toggle
Green - Other toggles
Blue - selection / copy / paste / fills / drains
reddish Brown - Undo
YellowyOrangey colour - Load/save inventories
Red - Set spawn point

Changed fast itemHax to values of 300 so the picks will actually 1 hit kill blocks.
This is for blocks like spikes/hellstone/away from spawn dungeon blocks etc

Rest of my personal preferences left out.

note: Itemdrops
Noticed there is a limit for the number of items allowed to be displaced and on the ground of 200. Couldn't find anything to let me change that number to 0 though....
Nvm found it, it's a constant =(
